### PR TITLE
Fix image action upload error

### DIFF
--- a/components/CustomActions.js
+++ b/components/CustomActions.js
@@ -4,7 +4,8 @@ import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
 import * as MediaLibrary from 'expo-media-library';
 import { storage } from '../firebaseConfig.js';
-import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { ref, uploadString, getDownloadURL } from 'firebase/storage';
+import * as FileSystem from 'expo-file-system';
 import { Alert } from 'react-native';
 
 
@@ -44,10 +45,13 @@ const CustomActions = ({ wrapperStyle, iconTextStyle, onSend, userID }) => {
   const uploadAndSendImage = async (imageURI) => {
     try {
       const uniqueRefString = generateReference(imageURI);
-      const response = await fetch(imageURI);
-      const blob = await response.blob();
+      // Read the selected image as a base64 string. This avoids issues
+      // with the fetch API on different platforms.
+      const base64Data = await FileSystem.readAsStringAsync(imageURI, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
       const newUploadRef = ref(storage, uniqueRefString);
-      const snapshot = await uploadBytes(newUploadRef, blob);
+      const snapshot = await uploadString(newUploadRef, base64Data, 'base64');
       const imageURL = await getDownloadURL(snapshot.ref);
       onSend([{ 
         _id: `${userID}-${new Date().getTime()}`,

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
 import { registerRootComponent } from 'expo';
+import React from 'react';
+import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 
 import App from './App';
 
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);
+const Main = () => (
+  <ActionSheetProvider>
+    <App />
+  </ActionSheetProvider>
+);
+
+registerRootComponent(Main);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "expo-image-picker": "~16.1.4",
     "expo-location": "~18.1.5",
     "expo-media-library": "~17.1.6",
+    "expo-file-system": "~18.1.10",
     "expo-status-bar": "~2.2.3",
     "firebase": "^11.10.0",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- use `expo-file-system` to read picked image as base64
- upload base64 string with `uploadString`
- include `expo-file-system` in dependencies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863451ae5c483209ae1d7965a50fe9e